### PR TITLE
Upgrade base image from node:24-alpine to node:25-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Install dependencies only when needed
-FROM node:24-alpine AS deps
+FROM node:25-alpine AS deps
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
@@ -8,14 +8,14 @@ COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 
 # Rebuild the source code only when needed
-FROM node:24-alpine AS builder
+FROM node:25-alpine AS builder
 WORKDIR /app
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
 RUN yarn build
 
 # Production image, copy all the files and run next
-FROM node:24-alpine AS runner
+FROM node:25-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV production


### PR DESCRIPTION
## Problem

All three `FROM` stages in `Dockerfile` used `node:24-alpine`. Every other Next.js service in the stack (`natwelch.com`, `writing`, `photos`, `realworldsre.com`, `timeclimbers.com`, `etu-web`) uses `node:25-alpine`. `lifeline` was the only outlier.

Node.js 25 ships security patches, V8 engine updates, and improved diagnostics over Node.js 24. While Node.js 24 is a valid LTS choice, keeping `lifeline` at a different major version adds maintenance overhead and means it misses security fixes present in 25.

## Fix

```diff
-FROM node:24-alpine AS deps
+FROM node:25-alpine AS deps

-FROM node:24-alpine AS builder
+FROM node:25-alpine AS builder

-FROM node:24-alpine AS runner
+FROM node:25-alpine AS runner
```

Three-line bump, no other changes. The non-root user (`nextjs`, UID 1001) was already in place.

## Testing

```bash
docker build -t lifeline-test .
docker run --rm lifeline-test node --version
# Expected: v25.x.x
docker run --rm lifeline-test id
# uid=1001(nextjs) ...
```

## Audit Note

**Reviewed**: Dockerfile, package.json  
**Found & fixed**: node:24-alpine → node:25-alpine (version consistency with all other Next.js repos in the stack)  
**Already good**: non-root user (nextjs, UID 1001), multi-stage build  
**Skipped / future run**: `package.json` has `node_modules` copied entirely in the runner (not standalone output tracing) — a future optimization would switch to Next.js standalone output to reduce the final image size
