### PR TITLE
chore: Add OCI annotation labels for GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ RUN rm -f .npmrc && yarn build
 
 # Production image, copy all the files and run next
 FROM node:25-alpine AS runner
+
+LABEL org.opencontainers.image.source=https://github.com/icco/lifeline
+LABEL org.opencontainers.image.description="A page to show my life."
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
Adds the GitHub-recommended OCI annotation labels to the Dockerfile so that
the GHCR package page links back to this repo and shows description/license.

See: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images

Labels added to the final image stage:
- `org.opencontainers.image.source`
- `org.opencontainers.image.description`
- `org.opencontainers.image.licenses` (where a recognizable LICENSE exists)