### PR TITLE
fix: stop pnpm verifying deps at runtime (502 on start)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 @icco:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+verify-deps-before-run=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN npm install -g pnpm@11.2.2
 WORKDIR /app
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
-RUN rm -f .npmrc && pnpm build
+RUN pnpm build
 
 # Production image, copy all the files and run next
 FROM node:26-alpine AS runner
@@ -36,6 +36,7 @@ COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/.npmrc ./.npmrc
 
 RUN addgroup -g 1001 -S nodejs
 RUN adduser -S nextjs -u 1001


### PR DESCRIPTION
pnpm 11's pre-run deps check tries to write `/app/_tmp_*`. Runtime user can't, container crash-loops, Caddy 502s.

Disable via `verify-deps-before-run=false` — deps were verified at build with `--frozen-lockfile`.

`.npmrc` only references `$GITHUB_TOKEN` (no embedded secret), so the builder's `rm -f .npmrc` is unnecessary — drop it, copy `.npmrc` to runner.