### PR TITLE
chore: standalone next.js + security headers

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 @icco:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
-verify-deps-before-run=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN pnpm build
 
 # Production image, copy all the files and run next
 FROM node:26-alpine AS runner
-RUN npm install -g pnpm@11.2.2
 
 LABEL org.opencontainers.image.source=https://github.com/icco/lifeline
 LABEL org.opencontainers.image.description="A page to show my life."
@@ -28,21 +27,17 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 ENV PORT=8080
-
-# You only need to copy next.config.js if you are NOT using the default configuration
-#COPY --from=builder /app/next.config.js ./
-
-COPY --from=builder /app/public ./public
-COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/package.json ./package.json
-COPY --from=builder /app/.npmrc ./.npmrc
+ENV HOSTNAME="0.0.0.0"
 
 RUN addgroup -g 1001 -S nodejs
 RUN adduser -S nextjs -u 1001
-RUN chown -R nextjs:nodejs /app/.next
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
 USER nextjs
 
 EXPOSE 8080
 
-CMD ["pnpm", "start"]
+CMD ["node", "server.js"]

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  output: "standalone",
+};
+
+export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,83 @@
 import type { NextConfig } from "next";
+import { createSecureHeaders } from "next-secure-headers";
+
+const port = process.env.PORT || "8080";
+const hostname = process.env.HOSTNAME || "localhost";
+const domain = process.env.DOMAIN || `http://${hostname}:${port}`;
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  poweredByHeader: false,
+  reactStrictMode: true,
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          {
+            key: "NEL",
+            value: JSON.stringify({ report_to: "default", max_age: 2592000 }),
+          },
+          {
+            key: "Report-To",
+            value: JSON.stringify({
+              group: "default",
+              max_age: 10886400,
+              endpoints: [
+                { url: "https://reportd.natwelch.com/report/lifeline" },
+              ],
+            }),
+          },
+          {
+            key: "Reporting-Endpoints",
+            value: 'default="https://reportd.natwelch.com/reporting/lifeline"',
+          },
+        ],
+      },
+      {
+        source: "/(.*)",
+        headers: createSecureHeaders({
+          contentSecurityPolicy: {
+            directives: {
+              defaultSrc: ["'none'"],
+              connectSrc: [
+                "'self'",
+                "https://*.natwelch.com",
+                domain,
+                domain.replace(/^https?/, "ws"),
+              ],
+              fontSrc: ["'self'", "https://fonts.gstatic.com"],
+              imgSrc: [
+                "'self'",
+                "data:",
+                "https://*.natwelch.com",
+                "https://icco.imgix.net",
+              ],
+              scriptSrc: [
+                "'self'",
+                "'unsafe-inline'",
+                "'unsafe-eval'",
+                "blob:",
+                "https://*.natwelch.com",
+                domain,
+              ],
+              styleSrc: [
+                "'self'",
+                "'unsafe-inline'",
+                "https://fonts.googleapis.com/",
+              ],
+              objectSrc: ["'none'"],
+              reportURI: "https://reportd.natwelch.com/report/lifeline",
+              reportTo: "default",
+            },
+            reportOnly: false,
+          },
+          referrerPolicy: "strict-origin-when-cross-origin",
+          expectCT: true,
+        }),
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "daisyui": "^5.5.20",
     "jsdom": "^29.1.1",
     "next": "^16.2.6",
+    "next-secure-headers": "^2.2.0",
     "postcss": "^8.5.15",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       next:
         specifier: ^16.2.6
         version: 16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next-secure-headers:
+        specifier: ^2.2.0
+        version: 2.2.0
       postcss:
         specifier: ^8.5.15
         version: 8.5.15
@@ -1803,6 +1806,10 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  next-secure-headers@2.2.0:
+    resolution: {integrity: sha512-C7OfZ9JdSJyYMz2ZBMI/WwNbt0qNjlFWX9afUp8nEUzbz6ez3JbeopdyxSZJZJAzVLIAfyk6n73rFpd4e22jRg==}
+    engines: {node: '>=10.0.0'}
 
   next@16.2.6:
     resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
@@ -4142,6 +4149,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   neo-async@2.6.2: {}
+
+  next-secure-headers@2.2.0: {}
 
   next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:


### PR DESCRIPTION
- Switch to Next.js standalone output; runner stage runs `node server.js`, no pnpm at runtime (avoids the bug from #311).
- Add CSP, NEL, Report-To, Reporting-Endpoints, Referrer-Policy via `next-secure-headers`. Reports to `reportd.natwelch.com/report/lifeline`.
- Revert `verify-deps-before-run=false` from `.npmrc` (dead config).

Tested locally: container starts clean, `/` and `/healthz` 200, all headers present.